### PR TITLE
Fix the worker to use the new response format

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -32,13 +32,23 @@ async function fetchFirmwareUpdate(request: Request) {
 	if (updateJSON?.version) {
 		const githubResponse = await fetch(`https://github.com/scratchminer/pd-ota/releases/download/${updateJSON.version}/update.json`);
 		const update = await githubResponse.json();
-		const redirectUrl = (await fetch(update.url, { redirect: 'manual' })).headers.get('location');
-
-		return new Response(JSON.stringify({ ...update, url: redirectUrl }), {
-			headers: { 'content-type': 'application/json' },
-		});
+		if (updateJSON.md5 === update.stock_md5 && updateJSON.version === update.version) {
+			// rev. A
+			const redirectUrl = (await fetch(update.dvt1, { redirect: 'manual' })).headers.get('location');
+			return new Response(JSON.stringify({ ...update, md5: update.dvt1_md5, url: redirectUrl }), {
+				headers: { 'content-type': 'application/json' },
+			});
+		}
+		else if () {
+			// rev. B
+			const redirectUrl = (await fetch(update.h7d1, { redirect: 'manual' })).headers.get('location');
+			return new Response(JSON.stringify({ ...update, md5: update.h7d1_md5, url: redirectUrl }), {
+				headers: { 'content-type': 'application/json' },
+			});
+		}
 	}
 
+	// either we're on the latest version or the GitHub action hasn't patched it yet
 	return new Response(null, { status: 204 });
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -39,7 +39,7 @@ async function fetchFirmwareUpdate(request: Request) {
 				headers: { 'content-type': 'application/json' },
 			});
 		}
-		else if () {
+		else if (updateJSON.version === update.version) {
 			// rev. B
 			const redirectUrl = (await fetch(update.h7d1, { redirect: 'manual' })).headers.get('location');
 			return new Response(JSON.stringify({ ...update, md5: update.h7d1_md5, url: redirectUrl }), {


### PR DESCRIPTION
I changed the response format in pd-ota, so here's some code to get the worker to understand it. Should handle both revisions now by checking the WOPR response's MD5 against the pre-calculated MD5 of the Rev. A FW, and serve the correct firmware for the device.

In addition, it now returns a 204 if the GitHub action hasn't patched the FW yet.